### PR TITLE
feat: add golden apple player head drops

### DIFF
--- a/src/main/java/com/stefancooper/SpigotUHC/Config.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Config.java
@@ -16,8 +16,9 @@ public class Config {
     private final Properties config;
     private final Properties defaultConfig;
     private final ConfigParser parser;
+    private final Plugin plugin;
 
-    public Config() {
+    public Config(Plugin plugin) {
         Properties props = new Properties();
         try {
             final FileInputStream in = new FileInputStream("./plugins/uhc_config.properties");
@@ -37,8 +38,13 @@ public class Config {
         this.config = props;
         this.defaultConfig = Defaults.createDefaultConfig();
         this.parser = new ConfigParser(this);
+        this.plugin = plugin;
         this.setDefaults();
         parser.executeConfigurables(this.config.entrySet().stream().map(prop -> parser.propertyToConfigurable((String) prop.getKey(), (String) prop.getValue())).toList());
+    }
+
+    public Plugin getPlugin() {
+        return plugin;
     }
 
     public String getProp(String key) {

--- a/src/main/java/com/stefancooper/SpigotUHC/ConfigParser.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/ConfigParser.java
@@ -4,10 +4,11 @@ import com.stefancooper.SpigotUHC.resources.UHCTeam;
 import com.stefancooper.SpigotUHC.types.Configurable;
 import org.bukkit.Bukkit;
 import org.bukkit.ChatColor;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.WorldBorder;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
-import org.bukkit.*;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
@@ -32,9 +33,8 @@ import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_GRACE_
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_INITIAL_SIZE;
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_SHRINKING_PERIOD;
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.fromString;
-import static com.stefancooper.SpigotUHC.resources.DeathAction.DROP_HEADS;
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_NAME;
-import static com.stefancooper.SpigotUHC.resources.ConfigKey.*;
+import static com.stefancooper.SpigotUHC.resources.Constants.PLAYER_HEAD;
 
 public class ConfigParser {
 
@@ -129,7 +129,7 @@ public class ConfigParser {
                 ItemStack apple = new ItemStack(Material.GOLDEN_APPLE, 1);
                 ItemMeta appleMeta = apple.getItemMeta();
                 apple.setItemMeta(appleMeta);
-                ShapedRecipe recipe = new ShapedRecipe(new NamespacedKey(config.getPlugin(), "PLAYER_HEAD"), apple);
+                ShapedRecipe recipe = new ShapedRecipe(new NamespacedKey(config.getPlugin(), PLAYER_HEAD), apple);
                 recipe.shape("   ", " X ", "   ");
                 recipe.setIngredient('X', Material.PLAYER_HEAD);
                 Bukkit.addRecipe(recipe);

--- a/src/main/java/com/stefancooper/SpigotUHC/ConfigParser.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/ConfigParser.java
@@ -7,8 +7,33 @@ import org.bukkit.ChatColor;
 import org.bukkit.WorldBorder;
 import org.bukkit.scoreboard.Scoreboard;
 import org.bukkit.scoreboard.Team;
+import org.bukkit.*;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.ItemMeta;
+
 import java.util.List;
 
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.COUNTDOWN_TIMER_LENGTH;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.GRACE_PERIOD_TIMER;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.ON_DEATH_ACTION;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.PLAYER_HEAD_GOLDEN_APPLE;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.RANDOM_TEAMS_ENABLED;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.RANDOM_TEAM_SIZE;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.TEAM_BLUE;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.TEAM_GREEN;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.TEAM_ORANGE;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.TEAM_RED;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.TEAM_YELLOW;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_CENTER_X;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_CENTER_Z;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_FINAL_SIZE;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_GRACE_PERIOD;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_INITIAL_SIZE;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_BORDER_SHRINKING_PERIOD;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.fromString;
+import static com.stefancooper.SpigotUHC.resources.DeathAction.DROP_HEADS;
+import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_NAME;
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.*;
 
 public class ConfigParser {
@@ -37,6 +62,7 @@ public class ConfigParser {
             case GRACE_PERIOD_TIMER -> new Configurable<>(GRACE_PERIOD_TIMER, Double.parseDouble(value));
             case ON_DEATH_ACTION -> new Configurable<>(ON_DEATH_ACTION, value);
             case COUNTDOWN_TIMER_LENGTH -> new Configurable<>(COUNTDOWN_TIMER_LENGTH, Double.parseDouble(value));
+            case PLAYER_HEAD_GOLDEN_APPLE -> new Configurable<>(PLAYER_HEAD_GOLDEN_APPLE, Boolean.parseBoolean((value)));
             case WORLD_NAME -> new Configurable<>(WORLD_NAME, value);
             case null -> null;
 
@@ -99,6 +125,14 @@ public class ConfigParser {
             case TEAM_ORANGE:
                 createTeam(new UHCTeam("Orange", (String) configurable.value(), ChatColor.GOLD ));
                 break;
+            case PLAYER_HEAD_GOLDEN_APPLE:
+                ItemStack apple = new ItemStack(Material.GOLDEN_APPLE, 1);
+                ItemMeta appleMeta = apple.getItemMeta();
+                apple.setItemMeta(appleMeta);
+                ShapedRecipe recipe = new ShapedRecipe(new NamespacedKey(config.getPlugin(), "PLAYER_HEAD"), apple);
+                recipe.shape("   ", " X ", "   ");
+                recipe.setIngredient('X', Material.PLAYER_HEAD);
+                Bukkit.addRecipe(recipe);
             default:
                 break;
         }

--- a/src/main/java/com/stefancooper/SpigotUHC/Defaults.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Defaults.java
@@ -12,6 +12,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import java.util.Properties;
 
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.*;
+import static com.stefancooper.SpigotUHC.resources.DeathAction.SPECTATE;
 
 public class Defaults {
 
@@ -24,7 +25,7 @@ public class Defaults {
     public static String DEFAULT_WORLD_BORDER_CENTER_X = "0";
     public static String DEFAULT_WORLD_BORDER_CENTER_Z = "0";
     public static String DEFAULT_GRACE_PERIOD_TIMER = "600";
-    public static String DEFAULT_ON_DEATH_ACTION = "spectator";
+    public static String DEFAULT_ON_DEATH_ACTION = SPECTATE.name;
     public static String DEFAULT_COUNTDOWN_TIMER_LENGTH = "10";
 
     public static Properties createDefaultConfig() {

--- a/src/main/java/com/stefancooper/SpigotUHC/Events.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Events.java
@@ -32,8 +32,6 @@ public class Events implements Listener {
             case KICK:
                 event.getEntity().kickPlayer("GG, you suck");
                 break;
-            case null:
-                break;
             default:
                 break;
         }

--- a/src/main/java/com/stefancooper/SpigotUHC/Events.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Events.java
@@ -1,9 +1,16 @@
 package com.stefancooper.SpigotUHC;
 
+import com.stefancooper.SpigotUHC.resources.DeathAction;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.meta.SkullMeta;
+
+import java.util.List;
 
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.*;
 
@@ -17,14 +24,30 @@ public class Events implements Listener {
 
     @EventHandler
     public void onDeath(PlayerDeathEvent event) {
-        if(config.getProp(ON_DEATH_ACTION.configName).equalsIgnoreCase("SPECTATOR")) {
-            event.getEntity().setGameMode(GameMode.SPECTATOR);
-        } else if (config.getProp(ON_DEATH_ACTION.configName).equalsIgnoreCase("KICK")) {
-            event.getEntity().kickPlayer("Get rekt");
+        switch (DeathAction.fromString(config.getProp(ON_DEATH_ACTION.configName))){
+            case SPECTATE:
+                event.getEntity().setGameMode(GameMode.SPECTATOR);
+                break;
+            case KICK:
+                event.getEntity().kickPlayer("GG, you suck");
+                break;
+            case null:
+                break;
+            default:
+                break;
+        }
+
+        if(Boolean.parseBoolean(config.getProp(PLAYER_HEAD_GOLDEN_APPLE.configName))){
+            Player player = event.getEntity();
+            ItemStack head = new ItemStack(Material.PLAYER_HEAD,1);
+            SkullMeta headMeta = (SkullMeta) head.getItemMeta();
+            headMeta.setDisplayName("PLAYER_HEAD");
+            headMeta.setLore(List.of("Put this item in a bench", "For a Golden Apple"));
+            headMeta.setOwningPlayer(player);
+            head.setItemMeta(headMeta);
+            player.getWorld().dropItemNaturally(player.getLocation(), head);
         }
     }
 }
 
-
 // View docs for various events https://hub.spigotmc.org/javadocs/bukkit/org/bukkit/event/package-summary.html
-

--- a/src/main/java/com/stefancooper/SpigotUHC/Events.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Events.java
@@ -13,6 +13,7 @@ import org.bukkit.inventory.meta.SkullMeta;
 import java.util.List;
 
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.*;
+import static com.stefancooper.SpigotUHC.resources.Constants.PLAYER_HEAD;
 
 public class Events implements Listener {
 
@@ -41,7 +42,8 @@ public class Events implements Listener {
             Player player = event.getEntity();
             ItemStack head = new ItemStack(Material.PLAYER_HEAD,1);
             SkullMeta headMeta = (SkullMeta) head.getItemMeta();
-            headMeta.setDisplayName("PLAYER_HEAD");
+            assert headMeta != null;
+            headMeta.setDisplayName(PLAYER_HEAD);
             headMeta.setLore(List.of("Put this item in a bench", "For a Golden Apple"));
             headMeta.setOwningPlayer(player);
             head.setItemMeta(headMeta);

--- a/src/main/java/com/stefancooper/SpigotUHC/Plugin.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Plugin.java
@@ -16,7 +16,7 @@ public class Plugin extends JavaPlugin implements Listener {
 
     // This is called when the plugin is loaded into the server.
     public void onEnable() {
-        config = new Config();
+        config = new Config(this);
         Defaults.setDefaultGameRules(this.config);
         Bukkit.getPluginManager().registerEvents(new Events(config), this);
         System.out.println("UHC Plugin enabled");

--- a/src/main/java/com/stefancooper/SpigotUHC/resources/ConfigKey.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/resources/ConfigKey.java
@@ -20,6 +20,7 @@ public enum ConfigKey {
     GRACE_PERIOD_TIMER("grace.period.timer"),
     ON_DEATH_ACTION("on.death.action"),
     COUNTDOWN_TIMER_LENGTH("countdown.timer.length"),
+    PLAYER_HEAD_GOLDEN_APPLE("player.head.golden.apple"),
     WORLD_NAME("world.name");
 
     public final String configName;

--- a/src/main/java/com/stefancooper/SpigotUHC/resources/Constants.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/resources/Constants.java
@@ -1,9 +1,6 @@
 package com.stefancooper.SpigotUHC.resources;
 
 public final class Constants {
-    private Constants(){
-
-    }
 
     public static final String PLAYER_HEAD = "PLAYER_HEAD";
 }

--- a/src/main/java/com/stefancooper/SpigotUHC/resources/Constants.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/resources/Constants.java
@@ -1,0 +1,9 @@
+package com.stefancooper.SpigotUHC.resources;
+
+public final class Constants {
+    private Constants(){
+
+    }
+
+    public static final String PLAYER_HEAD = "PLAYER_HEAD";
+}

--- a/src/main/java/com/stefancooper/SpigotUHC/resources/DeathAction.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/resources/DeathAction.java
@@ -2,8 +2,7 @@ package com.stefancooper.SpigotUHC.resources;
 
 public enum DeathAction {
     SPECTATE("spectate"),
-    KICK("kick"),
-    DROP_HEADS("drop.heads");
+    KICK("kick");
 
     public final String name;
 

--- a/src/main/java/com/stefancooper/SpigotUHC/resources/DeathAction.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/resources/DeathAction.java
@@ -1,0 +1,22 @@
+package com.stefancooper.SpigotUHC.resources;
+
+public enum DeathAction {
+    SPECTATE("spectate"),
+    KICK("kick"),
+    DROP_HEADS("drop.heads");
+
+    public final String name;
+
+    DeathAction(String name) {
+        this.name = name;
+    }
+
+    public static DeathAction fromString(String deathAction) {
+        for (DeathAction Key : DeathAction.values()) {
+            if (Key.name.equalsIgnoreCase(deathAction)) {
+                return Key;
+            }
+        }
+        return null;
+    }
+}

--- a/src/test/java/EventTest.java
+++ b/src/test/java/EventTest.java
@@ -3,6 +3,10 @@ import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import com.stefancooper.SpigotUHC.Plugin;
 import org.bukkit.GameMode;
+import org.bukkit.Material;
+import org.bukkit.World;
+import org.bukkit.entity.EntityType;
+import org.bukkit.entity.Item;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -15,11 +19,13 @@ public class EventTest {
 
     private static ServerMock server;
     private static Plugin plugin;
+    private static World world;
 
     @BeforeAll
     public static void load() {
         server = MockBukkit.mock();
         plugin = MockBukkit.load(Plugin.class);
+        world = server.getWorld(DEFAULT_WORLD_NAME);
     }
 
     @BeforeEach
@@ -54,5 +60,21 @@ public class EventTest {
         server.getOnlinePlayers();
         Assertions.assertEquals(15, server.getOnlinePlayers().size());
     }
+
+    @Test
+    @DisplayName("Test the on death event to ensure a player drops a head after death")
+    void testHeadDropOnDeath() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        server.execute("uhc", player, "set", "on.death.action=drop.heads");
+        player.damage(100);
+        if(!world.getEntities().stream().filter(entity -> entity.getType() == EntityType.ITEM && entity.getName().equals("PLAYER_HEAD")).toList().isEmpty()){
+            Item droppedItem = (Item) world.getEntities().get(0);
+            droppedItem.getItemStack();
+
+            Assertions.assertEquals(Material.PLAYER_HEAD, droppedItem.getType());
+        }
+    }
+
 
 }

--- a/src/test/java/EventTest.java
+++ b/src/test/java/EventTest.java
@@ -66,7 +66,7 @@ public class EventTest {
     void testHeadDropOnDeath() {
         PlayerMock player = server.addPlayer();
         player.setOp(true);
-        server.execute("uhc", player, "set", "on.death.action=drop.heads");
+        server.execute("uhc", player, "set", "player.head.golden.apple=true");
         player.damage(100);
         if(!world.getEntities().stream().filter(entity -> entity.getType() == EntityType.ITEM && entity.getName().equals("PLAYER_HEAD")).toList().isEmpty()){
             Item droppedItem = (Item) world.getEntities().get(0);

--- a/src/test/java/SetConfigTest.java
+++ b/src/test/java/SetConfigTest.java
@@ -1,8 +1,16 @@
 import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
+import be.seeseemelk.mockbukkit.inventory.InventoryMock;
 import com.stefancooper.SpigotUHC.Plugin;
+import org.bukkit.Bukkit;
+import org.bukkit.Material;
+import org.bukkit.NamespacedKey;
 import org.bukkit.World;
+import org.bukkit.inventory.Inventory;
+import org.bukkit.inventory.ItemStack;
+import org.bukkit.inventory.ShapedRecipe;
+import org.bukkit.inventory.meta.ItemMeta;
 import org.bukkit.scoreboard.Scoreboard;
 import org.junit.jupiter.api.*;
 
@@ -93,5 +101,40 @@ public class SetConfigTest {
         server.execute("uhc", admin, "set", "team.yellow=jawad");
         Assertions.assertTrue(scoreboard.getEntityTeam(stefan).getName().equals("Red"));
         Assertions.assertTrue(scoreboard.getEntityTeam(jawad).getName().equals("Yellow"));
+    }
+
+    @Test
+    @DisplayName("Test that the recipe for creating a golden apple from a player head works")
+    void testPlayerCanCraftGoldenAppleFromPlayerHead() {
+        PlayerMock player = server.addPlayer();
+        player.setOp(true);
+        server.execute("uhc", player, "set", "player.head.golden.apple=true");
+        ItemStack apple = new ItemStack(Material.GOLDEN_APPLE);
+        NamespacedKey key = new NamespacedKey(plugin, "golden_apple");
+        ShapedRecipe recipe = new ShapedRecipe(key, apple)
+                .shape("   ", " X ", "   ")
+                .setIngredient('X', Material.PLAYER_HEAD);
+        Bukkit.addRecipe(recipe);
+        InventoryMock craftingInventory = server.createInventory(null, 9, "Crafting");
+        craftingInventory.setItem(4, new ItemStack(Material.PLAYER_HEAD));
+
+        Assertions.assertTrue(isMatchingRecipe(craftingInventory, recipe));
+        Assertions.assertEquals(apple.getType(), recipe.getResult().getType());
+    }
+
+    private boolean isMatchingRecipe(InventoryMock inventory, ShapedRecipe recipe) {
+        String[] shape = recipe.getShape();
+        for (int row = 0; row < shape.length; row++) {
+            for (int col = 0; col < shape[row].length(); col++) {
+                int slotIndex = row * 3 + col;
+                char ingredientChar = shape[row].charAt(col);
+                ItemStack expected = recipe.getIngredientMap().get(ingredientChar);
+                ItemStack actual = inventory.getItem(slotIndex);
+
+                if (ingredientChar == ' ' && actual != null) return false;
+                if (expected != null && (actual == null || expected.getType() != actual.getType())) return false;
+            }
+        }
+        return true;
     }
 }

--- a/src/test/java/SetConfigTest.java
+++ b/src/test/java/SetConfigTest.java
@@ -15,6 +15,7 @@ import org.bukkit.scoreboard.Scoreboard;
 import org.junit.jupiter.api.*;
 
 import static com.stefancooper.SpigotUHC.Defaults.DEFAULT_WORLD_NAME;
+import static com.stefancooper.SpigotUHC.resources.Constants.PLAYER_HEAD;
 
 public class SetConfigTest {
 
@@ -110,29 +111,30 @@ public class SetConfigTest {
         player.setOp(true);
         server.execute("uhc", player, "set", "player.head.golden.apple=true");
         ItemStack apple = new ItemStack(Material.GOLDEN_APPLE);
-        NamespacedKey key = new NamespacedKey(plugin, "golden_apple");
-        ShapedRecipe recipe = new ShapedRecipe(key, apple)
-                .shape("   ", " X ", "   ")
-                .setIngredient('X', Material.PLAYER_HEAD);
-        Bukkit.addRecipe(recipe);
+        NamespacedKey key = new NamespacedKey(plugin, PLAYER_HEAD);
+        ShapedRecipe recipe = (ShapedRecipe) Bukkit.getRecipe(key);
+        Assertions.assertNotNull(recipe, "Recipe should be registered.");
+
+        // Simulate crafting inventory (3x3 grid with player head in the center (center = 4))
         InventoryMock craftingInventory = server.createInventory(null, 9, "Crafting");
         craftingInventory.setItem(4, new ItemStack(Material.PLAYER_HEAD));
 
-        Assertions.assertTrue(isMatchingRecipe(craftingInventory, recipe));
-        Assertions.assertEquals(apple.getType(), recipe.getResult().getType());
+        Assertions.assertTrue(isMatchingRecipe(craftingInventory, recipe), "Inventory should match the recipe.");
+        Assertions.assertEquals(apple.getType(), recipe.getResult().getType(), "Crafted item should be a golden apple.");
     }
 
+    // Helper method to check if crafting grid matches the recipe
     private boolean isMatchingRecipe(InventoryMock inventory, ShapedRecipe recipe) {
-        String[] shape = recipe.getShape();
-        for (int row = 0; row < shape.length; row++) {
-            for (int col = 0; col < shape[row].length(); col++) {
-                int slotIndex = row * 3 + col;
-                char ingredientChar = shape[row].charAt(col);
-                ItemStack expected = recipe.getIngredientMap().get(ingredientChar);
-                ItemStack actual = inventory.getItem(slotIndex);
+        String[] shape = recipe.getShape();                                         // Get the recipe's shape (array of strings where each row is a line of the crafting grid)
+        for (int row = 0; row < shape.length; row++) {                              // Loop through each row in the recipe's shape
+            for (int col = 0; col < shape[row].length(); col++) {                   // Loop through each character (ingredient) in the current row
+                int slotIndex = row * 3 + col;                                      // Convert 2D grid to flat index
+                char ingredientChar = shape[row].charAt(col);                       // Get the ingredient character from the recipe's shape (e.g., 'X' for PLAYER_HEAD)
+                ItemStack expected = recipe.getIngredientMap().get(ingredientChar); // Get the expected ItemStack for this ingredient character (e.g., Material.PLAYER_HEAD)
+                ItemStack actual = inventory.getItem(slotIndex);                    // Get the actual ItemStack from the simulated crafting grid (inventory)
 
-                if (ingredientChar == ' ' && actual != null) return false;
-                if (expected != null && (actual == null || expected.getType() != actual.getType())) return false;
+                if (ingredientChar == ' ' && actual != null) return false;          // Check if the recipe expects an empty slot but the inventory has an item there
+                if (expected != null && (actual == null || expected.getType() != actual.getType())) return false; // Check if the recipe expects an ingredient but the actual inventory slot is null or doesn't match
             }
         }
         return true;

--- a/src/test/java/StartTest.java
+++ b/src/test/java/StartTest.java
@@ -2,7 +2,6 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import com.stefancooper.SpigotUHC.Plugin;
-import org.bukkit.GameMode;
 import org.bukkit.Material;
 import org.bukkit.World;
 import org.bukkit.inventory.ItemStack;


### PR DESCRIPTION
Added a new enum for death events and heads can now drop on death and be creafted into golden apples.