### PR TITLE
feat: game modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,37 +1,123 @@
 # SpigotUHC
 
-Easily run a UHC on your Spigot Server
+Run a UHC on your Spigot Server.
 
-## Prereqs
+Want to contribute? See [Contributing](#contributing)
+
+## Installing
+
+1. Download the plugin - we don't currently have any accessible download links. Contact @stefan.cooper or any other contributor to retrieve a .jar file
+
+2. Add the plugin to your `plugins` folder in your Spigot server
+
+## Configure your UHC
+
+You can configure your UHC in the server (see [Configuring](#configuring)) or you can create a `uhc_config.properties` file inside your `plugins` folder. One of these will be created anyway after starting the server with this plugin installed.
+
+The following configurations are available for managing your UHC:
+
+```properties
+# Name of the minecraft world
+world.name=world
+# Difficulty of the game when UHC is live
+difficulty=EASY
+# Countdown to start the game after UHC start command issued
+countdown.timer.length=5
+# Grace period time (in seconds) before PVP is enabled
+grace.period.timer=600
+# Minimum distance (in blocks) that teams/players will be spread at start of UHC
+spread.min.distance=500
+# World border center X coord
+world.border.center.x=0
+# World border center Z coord
+world.border.center.z=0
+# Final size of the world border at the end of the UHC
+world.border.final.size=500
+# Grace period time (in seconds) before the border will begin to shrink
+world.border.grace.period=3600
+# Initial size world border at start of the UHC
+world.border.initial.size=2000
+# Time (in seconds) to shrink from the initial size to the final size
+world.border.shrinking.period=7200
+```
+
+Optional properties:
+
+```properties
+# Action to undertake when a player dies ("spectate" | "kick")
+on.death.action=spectate
+# Team Blue players (comma seperated e.g team.orange=player1,player2) - Note: This is caps sensitive
+team.blue=shurf
+# Team Orange players (comma seperated e.g team.orange=player1,player2) - Note: This is caps sensitive
+team.orange=JawadAJamil
+# Team Red players (comma seperated e.g team.orange=player1,player2) - Note: This is caps sensitive
+team.red=badTHREEEK
+# Team Green players (comma seperated e.g team.orange=player1,player2) - Note: This is caps sensitive
+team.green=chuckle
+# Team Yellow players (comma seperated e.g team.orange=player1,player2) - Note: This is caps sensitive
+team.yellow=StetoGuy
+# (optional) drop player heads who are killed that can be crafted into golden apples
+player.head.golden.apple=false|true
+```
+
+## Commands
+
+The following commands are available in game:
+
+### Configuring
+
+#### Set config value:
+
+`/uhc set world.border.initial.size=500`
+
+#### Set multiple config values:
+
+`/uhc set world.border.initial.size=500 world.border.final.size=250`
+
+#### View full config:
+
+`/uhc view config`
+
+#### View a specific config value:
+
+`/uhc view world.border.initial.size`
+
+### Running
+
+#### Start the UHC:
+
+`/uhc start`
+
+#### End/cancel the UHC:
+
+`/uhc cancel`
+
+## Contributing
+
+Contact @stefan.cooper for information about contributing. This is an open source project so if you feel like you want to add something, just raise a PR!
+
+### Prereqs
 
 - Java 21
 - Maven
 - Git
 
-## Getting started
+### Getting started
 
 1. Clone the repo
 
 2. Run the following command to build the spigot server dev env
-   
+
    ```
    REFRESH_BUILD=true ./setup_server.sh
    ```
 
    Note: This may take a long time (10-15min)
 
-## Running
+### Running
 
 1. Run Spigot server
 
    ```
    ./run_server.sh
    ```
-
-## Configure your UHC
-
-TODO
-
-## Run your UHC
-
-TODO

--- a/src/main/java/com/stefancooper/SpigotUHC/Config.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Config.java
@@ -97,4 +97,10 @@ public class Config {
         Defaults.setDefaultGameRules(this);
     }
 
+    public void trigger() {
+        setProp(WORLD_NAME.configName, (String) defaultConfig.get(WORLD_NAME.configName));
+        config.forEach((key, value) -> setProp((String) key, (String) value));
+        Defaults.setDefaultGameRules(this);
+    }
+
 }

--- a/src/main/java/com/stefancooper/SpigotUHC/Defaults.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Defaults.java
@@ -2,6 +2,7 @@ package com.stefancooper.SpigotUHC;
 
 import org.bukkit.Bukkit;
 import org.bukkit.Difficulty;
+import org.bukkit.GameMode;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.bukkit.scoreboard.Criteria;
@@ -54,6 +55,7 @@ public class Defaults {
         world.setGameRule(GameRule.DO_INSOMNIA, false);
         // set pvp to false, will be enabled when /uhc start is ran
         world.setPVP(false);
+        Bukkit.getOnlinePlayers().forEach(player -> player.setGameMode(GameMode.ADVENTURE));
         final Scoreboard board = Bukkit.getScoreboardManager().getMainScoreboard();
         final Objective healthObjective;
         if (board.getObjective(HEALTH_OBJECTIVE) == null) {

--- a/src/main/java/com/stefancooper/SpigotUHC/Events.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Events.java
@@ -11,6 +11,7 @@ import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -63,6 +64,18 @@ public class Events implements Listener {
         Location deathLocation = player.getLastDeathLocation();
         if (deathLocation != null && player.getGameMode().equals(GameMode.SPECTATOR)) {
             event.setRespawnLocation(deathLocation);
+        }
+    }
+
+    @EventHandler
+    public void onJoin(PlayerJoinEvent event) {
+        GameMode currentGamemode = event.getPlayer().getGameMode();
+        if (currentGamemode == GameMode.SPECTATOR) {
+            return;
+        } else if (config.getPlugin().getStarted()) {
+            event.getPlayer().setGameMode(GameMode.SURVIVAL);
+        } else {
+            event.getPlayer().setGameMode(GameMode.ADVENTURE);
         }
     }
 }

--- a/src/main/java/com/stefancooper/SpigotUHC/Plugin.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Plugin.java
@@ -1,5 +1,6 @@
 package com.stefancooper.SpigotUHC;
 
+import com.stefancooper.SpigotUHC.commands.CancelCommand;
 import com.stefancooper.SpigotUHC.commands.SetConfigCommand;
 import com.stefancooper.SpigotUHC.commands.StartCommand;
 import com.stefancooper.SpigotUHC.commands.ViewConfigCommand;
@@ -13,12 +14,14 @@ import java.util.Arrays;
 public class Plugin extends JavaPlugin implements Listener {
 
     private Config config;
+    private boolean started;
 
     // This is called when the plugin is loaded into the server.
     public void onEnable() {
         config = new Config(this);
         Defaults.setDefaultGameRules(this.config);
         Bukkit.getPluginManager().registerEvents(new Events(config), this);
+        started = false;
         System.out.println("UHC Plugin enabled");
     }
 
@@ -47,11 +50,21 @@ public class Plugin extends JavaPlugin implements Listener {
                 case StartCommand.COMMAND_KEY:
                     new StartCommand(sender, cmd, getCommandArgs(args), config).execute();
                     return true;
+                case CancelCommand.COMMAND_KEY:
+                    new CancelCommand(sender, cmd, getCommandArgs(args), config).execute();
+                    return true;
                 default:
                     break;
             }
         }
         return false;
     }
+
+    public void setStarted(boolean started) {
+        this.started = started;
+    }
+
+    // Has the UHC started?
+    public boolean getStarted() { return started; }
 }
 

--- a/src/main/java/com/stefancooper/SpigotUHC/commands/CancelCommand.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/commands/CancelCommand.java
@@ -1,0 +1,20 @@
+package com.stefancooper.SpigotUHC.commands;
+
+import com.stefancooper.SpigotUHC.Config;
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandSender;
+
+public class CancelCommand extends AbstractCommand {
+
+    public static final String COMMAND_KEY = "cancel";
+
+    public CancelCommand(CommandSender sender, Command cmd, String[] args, Config config) {
+        super(sender, cmd, args, config);
+    }
+
+    @Override
+    public void execute() {
+        getConfig().getPlugin().setStarted(false);
+        getConfig().trigger();
+    }
+}

--- a/src/main/java/com/stefancooper/SpigotUHC/commands/StartCommand.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/commands/StartCommand.java
@@ -58,6 +58,8 @@ public class StartCommand extends AbstractCommand {
             player.addPotionEffect(PotionEffectType.SLOWNESS.createEffect(Utils.secondsToTicks(countdownTimer), 128));
         });
 
+        Bukkit.setDefaultGameMode(GameMode.SURVIVAL);
+
         // Actions on the world
         world.getWorldBorder().setSize(Double.parseDouble(getConfig().getProp(WORLD_BORDER_INITIAL_SIZE.configName)));
         world.setTime(1000);
@@ -92,6 +94,8 @@ public class StartCommand extends AbstractCommand {
                 timer.schedule(countdown(curr, world), curr * 1000L);
             }
         }
+
+        getConfig().getPlugin().setStarted(true);
     }
 
     private TimerTask countdown(int remaining, World world) {

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -26,3 +26,11 @@ commands:
       View a specific config value:
 
       /uhc view world.border.initial.size
+      
+      Start the UHC:
+      
+      /uhc start
+      
+      End/cancel the UHC:
+      
+      /uhc cancel

--- a/src/test/java/EventTest.java
+++ b/src/test/java/EventTest.java
@@ -93,5 +93,44 @@ public class EventTest {
         Assertions.assertEquals(deathLocation, respawnEvent.getRespawnLocation(), "Player should respawn at their death location");
     }
 
+    @Test
+    @DisplayName("Correct game mode is set when joining the server")
+    void testGameModeSet() {
+        PlayerMock admin = server.addPlayer();
+        admin.setOp(true);
+
+        PlayerMock player = server.addPlayer();
+        Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
+
+        server.execute("uhc", admin, "start");
+
+        Assertions.assertEquals(GameMode.SURVIVAL, player.getGameMode());
+
+        player.disconnect();
+        player.reconnect();
+
+        Assertions.assertEquals(GameMode.SURVIVAL, player.getGameMode());
+
+        player.damage(100);
+        player.respawn();
+
+        Assertions.assertEquals(GameMode.SPECTATOR, player.getGameMode());
+
+        player.disconnect();
+        player.reconnect();
+
+        Assertions.assertEquals(GameMode.SPECTATOR, player.getGameMode());
+
+        server.execute("uhc", admin, "cancel");
+
+        Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
+
+        player.disconnect();
+        player.reconnect();
+
+        Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
+
+    }
+
 
 }

--- a/src/test/java/PluginTest.java
+++ b/src/test/java/PluginTest.java
@@ -2,6 +2,7 @@ import be.seeseemelk.mockbukkit.MockBukkit;
 import be.seeseemelk.mockbukkit.ServerMock;
 import be.seeseemelk.mockbukkit.entity.PlayerMock;
 import com.stefancooper.SpigotUHC.Plugin;
+import org.bukkit.GameMode;
 import org.bukkit.GameRule;
 import org.bukkit.World;
 import org.junit.jupiter.api.*;
@@ -36,10 +37,12 @@ public class PluginTest {
     @Test
     @DisplayName("Test correct game rules were applied")
     void testGameRules() {
+        PlayerMock player = server.addPlayer();
         Assertions.assertNotNull(world);
         Assertions.assertFalse(world.getGameRuleValue(GameRule.DO_INSOMNIA));
         Assertions.assertFalse(world.getGameRuleValue(GameRule.NATURAL_REGENERATION));
         Assertions.assertFalse(world.getPVP());
+        Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
     }
 
     @Test

--- a/src/test/java/StartTest.java
+++ b/src/test/java/StartTest.java
@@ -98,6 +98,13 @@ public class StartTest {
                 "difficulty=HARD"
         );
 
+        server.getOnlinePlayers().forEach(player -> {
+            Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
+            Assertions.assertNull(player.getPotionEffect(PotionEffectType.SLOWNESS));
+            Assertions.assertNull(player.getPotionEffect(PotionEffectType.JUMP_BOOST));
+            Assertions.assertNull(player.getPotionEffect(PotionEffectType.MINING_FATIGUE));
+        });
+
         server.execute("uhc", admin, "start");
 
         // Initial start
@@ -105,6 +112,7 @@ public class StartTest {
         Assertions.assertEquals(Difficulty.PEACEFUL, world.getDifficulty());
         Assertions.assertEquals(50, world.getWorldBorder().getSize());
         server.getOnlinePlayers().forEach(player -> {
+            Assertions.assertEquals(GameMode.SURVIVAL, player.getGameMode());
             Assertions.assertEquals(128, player.getPotionEffect(PotionEffectType.SLOWNESS).getAmplifier());
             Assertions.assertEquals(128, player.getPotionEffect(PotionEffectType.JUMP_BOOST).getAmplifier());
             Assertions.assertEquals(3, player.getPotionEffect(PotionEffectType.MINING_FATIGUE).getAmplifier());


### PR DESCRIPTION
- add `/uhc cancel` to cancel/end a uhc
- set adventure mode on initial join and track the current status of the uhc so that the correct game mode is applied on rejoin
- add docs for properties

Signed-off-by: Stefan Cooper <stefan.cooper27@gmail.com>