### PR TITLE
feat: prevent player movement via cancelling event

### DIFF
--- a/src/main/java/com/stefancooper/SpigotUHC/Config.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Config.java
@@ -7,6 +7,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.util.Comparator;
 import java.util.Properties;
+import java.util.Timer;
 import java.util.stream.Stream;
 import static com.stefancooper.SpigotUHC.resources.ConfigKey.WORLD_NAME;
 
@@ -16,6 +17,7 @@ public class Config {
     private final Properties defaultConfig;
     private final ConfigParser parser;
     private final Plugin plugin;
+    private Timer timer;
 
     public Config(Plugin plugin) {
         Properties props = new Properties();
@@ -39,11 +41,21 @@ public class Config {
         this.parser = new ConfigParser(this);
         this.plugin = plugin;
         this.setDefaults();
+        timer = new Timer();
         parser.executeConfigurables(this.config.entrySet().stream().map(prop -> parser.propertyToConfigurable((String) prop.getKey(), (String) prop.getValue())).toList());
     }
 
     public Plugin getPlugin() {
         return plugin;
+    }
+
+    public Timer getTimer() {
+        return timer;
+    }
+
+    public void cancelTimer() {
+        timer.cancel();
+        timer = new Timer();
     }
 
     public String getProp(String key) {

--- a/src/main/java/com/stefancooper/SpigotUHC/Defaults.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Defaults.java
@@ -55,6 +55,7 @@ public class Defaults {
         world.setGameRule(GameRule.DO_INSOMNIA, false);
         // set pvp to false, will be enabled when /uhc start is ran
         world.setPVP(false);
+        config.getPlugin().setCountingDown(false);
         Bukkit.getOnlinePlayers().forEach(player -> player.setGameMode(GameMode.ADVENTURE));
         final Scoreboard board = Bukkit.getScoreboardManager().getMainScoreboard();
         final Objective healthObjective;

--- a/src/main/java/com/stefancooper/SpigotUHC/Events.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Events.java
@@ -12,6 +12,7 @@ import org.bukkit.event.EventHandler;
 import org.bukkit.event.Listener;
 import org.bukkit.event.entity.PlayerDeathEvent;
 import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.player.PlayerRespawnEvent;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.meta.SkullMeta;
@@ -76,6 +77,15 @@ public class Events implements Listener {
             event.getPlayer().setGameMode(GameMode.SURVIVAL);
         } else {
             event.getPlayer().setGameMode(GameMode.ADVENTURE);
+        }
+    }
+
+    @EventHandler
+    public void onMove(PlayerMoveEvent event) {
+        final Location getTo = event.getTo();
+        final Location getFrom = event.getFrom();
+        if (config.getPlugin().isCountingDown() && getTo != null && (getTo.getY() > getFrom.getY() || getTo.getX() != getFrom.getX() || getTo.getZ() != getFrom.getZ())) {
+            event.setCancelled(true);
         }
     }
 }

--- a/src/main/java/com/stefancooper/SpigotUHC/Plugin.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/Plugin.java
@@ -15,6 +15,7 @@ public class Plugin extends JavaPlugin implements Listener {
 
     private Config config;
     private boolean started;
+    private boolean countingDown;
 
     // This is called when the plugin is loaded into the server.
     public void onEnable() {
@@ -66,5 +67,9 @@ public class Plugin extends JavaPlugin implements Listener {
 
     // Has the UHC started?
     public boolean getStarted() { return started; }
+
+    public boolean isCountingDown() { return countingDown; }
+
+    public void setCountingDown(boolean countingDown) { this.countingDown = countingDown; }
 }
 

--- a/src/main/java/com/stefancooper/SpigotUHC/commands/CancelCommand.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/commands/CancelCommand.java
@@ -16,5 +16,6 @@ public class CancelCommand extends AbstractCommand {
     public void execute() {
         getConfig().getPlugin().setStarted(false);
         getConfig().trigger();
+        getConfig().cancelTimer();
     }
 }

--- a/src/main/java/com/stefancooper/SpigotUHC/commands/StartCommand.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/commands/StartCommand.java
@@ -75,7 +75,7 @@ public class StartCommand extends AbstractCommand {
         getSender().getServer().dispatchCommand(getSender(), spreadCommand);
 
         // Timed actions
-        Timer timer = new Timer();
+        Timer timer = getConfig().getTimer();
         Optional<String> gracePeriod = Optional.ofNullable(getConfig().getProp(GRACE_PERIOD_TIMER.configName));
         Optional<String> worldBorderGracePeriod = Optional.ofNullable(getConfig().getProp(WORLD_BORDER_GRACE_PERIOD.configName));
 

--- a/src/main/java/com/stefancooper/SpigotUHC/commands/StartCommand.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/commands/StartCommand.java
@@ -53,9 +53,7 @@ public class StartCommand extends AbstractCommand {
             player.getInventory().clear();
             player.setExp(0);
             player.setGameMode(GameMode.SURVIVAL);
-            player.addPotionEffect(PotionEffectType.JUMP_BOOST.createEffect(Utils.secondsToTicks(countdownTimer), 128));
             player.addPotionEffect(PotionEffectType.MINING_FATIGUE.createEffect(Utils.secondsToTicks(countdownTimer), 3));
-            player.addPotionEffect(PotionEffectType.SLOWNESS.createEffect(Utils.secondsToTicks(countdownTimer), 128));
         });
 
         Bukkit.setDefaultGameMode(GameMode.SURVIVAL);
@@ -89,6 +87,7 @@ public class StartCommand extends AbstractCommand {
         // Countdown timer
         for (int curr = 0; curr <= countdownTimer; curr++) {
             if (curr == 0) {
+                getConfig().getPlugin().setCountingDown(true);
                 timer.schedule(countdown(curr, world), 0L);
             } else {
                 timer.schedule(countdown(curr, world), curr * 1000L);
@@ -112,6 +111,7 @@ public class StartCommand extends AbstractCommand {
                     // Countdown over!
                     Bukkit.getOnlinePlayers().forEach(player -> player.sendTitle(Integer.toString(timeLeft), "Go!"));
                     world.setDifficulty(Difficulty.valueOf(getConfig().getProp(DIFFICULTY.configName)));
+                    getConfig().getPlugin().setCountingDown(false);
                 } else {
                     Bukkit.getOnlinePlayers().forEach(player -> player.sendTitle(Integer.toString(timeLeft), "Starting soon..."));
                 }

--- a/src/test/java/EventTest.java
+++ b/src/test/java/EventTest.java
@@ -129,7 +129,54 @@ public class EventTest {
         player.reconnect();
 
         Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
+    }
 
+    @Test
+    void preventMovementDuringCountdown() throws InterruptedException {
+        PlayerMock admin = server.addPlayer();
+        admin.setOp(true);
+
+        PlayerMock player = server.addPlayer();
+
+        server.execute("uhc", admin, "set", "countdown.timer.length=5");
+
+        Location initialLocation = player.getLocation();
+        Location newLocation1 = initialLocation.clone();
+        Location newLocation2 = initialLocation.clone();
+        Location newLocation3 = initialLocation.clone();
+        newLocation1.setX(initialLocation.x() + 1);
+        newLocation2.setY(initialLocation.y() + 1);
+        newLocation3.setZ(initialLocation.z() + 1);
+
+        // Assert that they can move in all directions and they get moved
+        player.simulatePlayerMove(newLocation1);
+        Assertions.assertEquals(player.getLocation(), newLocation1);
+        player.simulatePlayerMove(newLocation2);
+        Assertions.assertEquals(player.getLocation(), newLocation2);
+        player.simulatePlayerMove(newLocation3);
+        Assertions.assertEquals(player.getLocation(), newLocation3);
+
+        // Reset back to original location
+        player.simulatePlayerMove(initialLocation);
+        server.execute("uhc", admin, "start");
+
+        Assertions.assertEquals(player.getLocation(), initialLocation);
+        player.simulatePlayerMove(newLocation1);
+        Assertions.assertEquals(player.getLocation(), initialLocation);
+        player.simulatePlayerMove(newLocation2);
+        Assertions.assertEquals(player.getLocation(), initialLocation);
+        player.simulatePlayerMove(newLocation3);
+        Assertions.assertEquals(player.getLocation(), initialLocation);
+
+        // even though we set the countdown to 5 seconds, we count 0 as an extra second so wait for 6 seconds
+        Thread.sleep(6000);
+
+        player.simulatePlayerMove(newLocation1);
+        Assertions.assertEquals(player.getLocation(), newLocation1);
+        player.simulatePlayerMove(newLocation2);
+        Assertions.assertEquals(player.getLocation(), newLocation2);
+        player.simulatePlayerMove(newLocation3);
+        Assertions.assertEquals(player.getLocation(), newLocation3);
     }
 
 

--- a/src/test/java/StartTest.java
+++ b/src/test/java/StartTest.java
@@ -75,8 +75,6 @@ public class StartTest {
             Assertions.assertEquals(0, player.getExp());
             Assertions.assertEquals(0, Arrays.stream(player.getInventory().getContents()).filter(item -> item != null && item.getType() != Material.AIR).toList().size());
             Assertions.assertEquals(GameMode.SURVIVAL, player.getGameMode());
-            Assertions.assertEquals(128, player.getPotionEffect(PotionEffectType.SLOWNESS).getAmplifier());
-            Assertions.assertEquals(128, player.getPotionEffect(PotionEffectType.JUMP_BOOST).getAmplifier());
             Assertions.assertEquals(3, player.getPotionEffect(PotionEffectType.MINING_FATIGUE).getAmplifier());
         });
     }
@@ -100,8 +98,6 @@ public class StartTest {
 
         server.getOnlinePlayers().forEach(player -> {
             Assertions.assertEquals(GameMode.ADVENTURE, player.getGameMode());
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.SLOWNESS));
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.JUMP_BOOST));
             Assertions.assertNull(player.getPotionEffect(PotionEffectType.MINING_FATIGUE));
         });
 
@@ -113,11 +109,10 @@ public class StartTest {
         Assertions.assertEquals(50, world.getWorldBorder().getSize());
         server.getOnlinePlayers().forEach(player -> {
             Assertions.assertEquals(GameMode.SURVIVAL, player.getGameMode());
-            Assertions.assertEquals(128, player.getPotionEffect(PotionEffectType.SLOWNESS).getAmplifier());
-            Assertions.assertEquals(128, player.getPotionEffect(PotionEffectType.JUMP_BOOST).getAmplifier());
             Assertions.assertEquals(3, player.getPotionEffect(PotionEffectType.MINING_FATIGUE).getAmplifier());
         });
 
+        // even though we set the countdown to 2 seconds, we count 0 as an extra second so wait for 3 seconds
         Thread.sleep(3000);
         schedule.performTicks(41L); // advance ticks for potion effect
 
@@ -125,8 +120,6 @@ public class StartTest {
         Assertions.assertEquals(Difficulty.HARD, world.getDifficulty());
         Assertions.assertFalse(world.getPVP());
         server.getOnlinePlayers().forEach(player -> {
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.SLOWNESS));
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.JUMP_BOOST));
             Assertions.assertNull(player.getPotionEffect(PotionEffectType.MINING_FATIGUE));
         });
         Assertions.assertEquals(50, world.getWorldBorder().getSize());
@@ -137,8 +130,6 @@ public class StartTest {
         Assertions.assertEquals(Difficulty.HARD, world.getDifficulty());
         Assertions.assertTrue(world.getPVP());
         server.getOnlinePlayers().forEach(player -> {
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.SLOWNESS));
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.JUMP_BOOST));
             Assertions.assertNull(player.getPotionEffect(PotionEffectType.MINING_FATIGUE));
         });
         Assertions.assertEquals(50, world.getWorldBorder().getSize());
@@ -149,8 +140,6 @@ public class StartTest {
         Assertions.assertEquals(Difficulty.HARD, world.getDifficulty());
         Assertions.assertTrue(world.getPVP());
         server.getOnlinePlayers().forEach(player -> {
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.SLOWNESS));
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.JUMP_BOOST));
             Assertions.assertNull(player.getPotionEffect(PotionEffectType.MINING_FATIGUE));
         });
         Assertions.assertEquals(50, world.getWorldBorder().getSize());
@@ -162,8 +151,6 @@ public class StartTest {
         Assertions.assertEquals(Difficulty.HARD, world.getDifficulty());
         Assertions.assertTrue(world.getPVP());
         server.getOnlinePlayers().forEach(player -> {
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.SLOWNESS));
-            Assertions.assertNull(player.getPotionEffect(PotionEffectType.JUMP_BOOST));
             Assertions.assertNull(player.getPotionEffect(PotionEffectType.MINING_FATIGUE));
         });
         Assertions.assertEquals(10, world.getWorldBorder().getSize());


### PR DESCRIPTION
- instead of using potion effects

Signed-off-by: Stefan Cooper <stefan.cooper27@gmail.com>