### PR TITLE
(major bump) feat: add support for multiple revive locs

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,16 @@ revive.lose.max.health=4
 revive.time=90
 # X coordinate for the center of the revive location
 revive.location.x=-30
+# for multiple revive locations, you can comma seperate each x coordinate of each location
+# revive.location.x=-30,100,45
 # Y coordinate for the center of the revive location
 revive.location.y=64
+# for multiple revive locations, you can comma seperate each y coordinate of each location
+# revive.location.y=64,68,75
 # Z coordinate for the center of the revive location
 revive.location.z=11
+# for multiple revive locations, you can comma seperate each z coordinate of each location
+# revive.location.z=11,222,-42
 # Diameter/size of the revive location
 revive.location.size=10
 # reive with any player head

--- a/pom.xml
+++ b/pom.xml
@@ -53,7 +53,7 @@
     </build>
 
     <properties>
-        <UHCPlugin.version>1.17.0</UHCPlugin.version>
+        <UHCPlugin.version>2.0.0</UHCPlugin.version>
         <maven.compiler.source>21</maven.compiler.source>
         <maven.compiler.target>21</maven.compiler.target>
     </properties>

--- a/src/main/java/com/stefancooper/SpigotUHC/ConfigParser.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/ConfigParser.java
@@ -117,9 +117,9 @@ public class ConfigParser {
             case REVIVE_TIME -> new Configurable<>(REVIVE_TIME, Integer.parseInt(value));
             case REVIVE_HP -> new Configurable<>(REVIVE_HP, Integer.parseInt(value));
             case REVIVE_LOCATION_SIZE -> new Configurable<>(REVIVE_LOCATION_SIZE, Integer.parseInt(value));
-            case REVIVE_LOCATION_X -> new Configurable<>(REVIVE_LOCATION_X, Integer.parseInt(value));
-            case REVIVE_LOCATION_Y -> new Configurable<>(REVIVE_LOCATION_Y, Integer.parseInt(value));
-            case REVIVE_LOCATION_Z -> new Configurable<>(REVIVE_LOCATION_Z, Integer.parseInt(value));
+            case REVIVE_LOCATION_X -> new Configurable<>(REVIVE_LOCATION_X, value);
+            case REVIVE_LOCATION_Y -> new Configurable<>(REVIVE_LOCATION_Y, value);
+            case REVIVE_LOCATION_Z -> new Configurable<>(REVIVE_LOCATION_Z, value);
             case REVIVE_LOSE_MAX_HEALTH -> new Configurable<>(REVIVE_LOSE_MAX_HEALTH, Integer.parseInt(value));
 
             case REVIVE_ANY_HEAD -> new Configurable<>(REVIVE_ANY_HEAD, Boolean.parseBoolean(value));

--- a/src/main/java/com/stefancooper/SpigotUHC/enums/ConfigKey.java
+++ b/src/main/java/com/stefancooper/SpigotUHC/enums/ConfigKey.java
@@ -44,9 +44,9 @@ public enum ConfigKey {
 
     // Revive config
     REVIVE_ENABLED("revive.enabled"), // Enable revive
-    REVIVE_LOCATION_X("revive.location.x"), // Revive x center location
-    REVIVE_LOCATION_Y("revive.location.y"), // Revive y center location
-    REVIVE_LOCATION_Z("revive.location.z"), // Revive z center location
+    REVIVE_LOCATION_X("revive.location.x"), // Revive x center locations (comma seperated)
+    REVIVE_LOCATION_Y("revive.location.y"), // Revive y center locations (comma seperated)
+    REVIVE_LOCATION_Z("revive.location.z"), // Revive z center location (comma seperated)
     REVIVE_TIME("revive.time"), // How many seconds it takes to revive
     REVIVE_LOCATION_SIZE("revive.location.size"), // Diameter of revive location
     REVIVE_HP("revive.hp"), // Revivee starting hp

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,5 +1,5 @@
 name: SpigotUHC
-version: 1.17.0
+version: 2.0.0
 author: Stefan Cooper
 main: com.stefancooper.SpigotUHC.Plugin
 api-version: 1.21


### PR DESCRIPTION
BREAKING: auto generate revive locations with bedrock. If you have a world where you do not want this. This update is not for you. Raise an issue on GitHub and we can add support for customising the block for the revive area.

Signed-off-by: Stefan Cooper <stefan.cooper27@gmail.com>